### PR TITLE
fix coverage path location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - #npm run snapshot # Visual regression tests
 
 after_script:
-  - ./cc-test-reporter format-coverage -t lcov "./coverage/HeadlessChrome 74.0.3729 (Mac OS X 10.14.5)/lcov.info"
+  - ./cc-test-reporter format-coverage -t lcov "./coverage/lcov.info"
   - ./cc-test-reporter upload-coverage
 
 notifications:


### PR DESCRIPTION
Fix path location of code climate coverage report. Forgot to change when testing locally. 